### PR TITLE
Migrate to newer driver spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,14 +4,10 @@
   :dependencies
   [[com.jayway.jsonpath/json-path "2.3.0"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies
-    [[org.clojure/clojure "1.9.0"]
+    [[org.clojure/clojure "1.10.1"]
      [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -5,6 +5,7 @@ info:
   description: HTTP/REST API driver
 driver:
   name: http
+  display-name: HTTP/REST API
   lazy-load: true
   connection-properties:
     - name: definitions


### PR DESCRIPTION
As mentioned in the issue https://github.com/tlrobinson/metabase-http-driver/issues/3 the driver is not working on newer Metabase version because there's a breaking change in version 0.35.0 regarding [`execute-query` replaced by `execute-query-reducible`](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors#execute-query-replaced-by-execute-query-reducible). I tried to migrate the driver so it complies with the changes. As I'm new to Clojure (since 2 weeks ago), I think this is a nice problem for me to get my hands dirty so I can take this as my own exercise for learning Clojure. 